### PR TITLE
Import tcpdump-4.9.2-3.el7.src.rpm as part of XS-1557

### DIFF
--- a/SOURCES/0001-icmp6-print-Reachable-Time-and-Retransmit-Time-from-.patch
+++ b/SOURCES/0001-icmp6-print-Reachable-Time-and-Retransmit-Time-from-.patch
@@ -1,0 +1,26 @@
+From 71083535d1aa4cf0f858553dda2efcace31f4967 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Oct 2014 13:34:24 +0200
+Subject: [PATCH 01/13] icmp6: print Reachable Time and Retransmit Time from
+ ICMPv6 as milliseconds
+
+---
+ print-icmp6.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/print-icmp6.c b/print-icmp6.c
+index 42fe19f..1980a7a 100644
+--- a/print-icmp6.c
++++ b/print-icmp6.c
+@@ -1034,7 +1034,7 @@ icmp6_print(netdissect_options *ndo,
+ 			p = (const struct nd_router_advert *)dp;
+ 			ND_TCHECK(p->nd_ra_retransmit);
+ 			ND_PRINT((ndo,"\n\thop limit %u, Flags [%s]" \
+-                                  ", pref %s, router lifetime %us, reachable time %us, retrans time %us",
++                                  ", pref %s, router lifetime %us, reachable time %ums, retrans time %ums",
+                                   (u_int)p->nd_ra_curhoplimit,
+                                   bittok2str(icmp6_opt_ra_flag_values,"none",(p->nd_ra_flags_reserved)),
+                                   get_rtpref(p->nd_ra_flags_reserved),
+-- 
+2.13.5
+

--- a/SOURCES/0002-Use-getnameinfo-instead-of-gethostbyaddr.patch
+++ b/SOURCES/0002-Use-getnameinfo-instead-of-gethostbyaddr.patch
@@ -1,0 +1,106 @@
+From ac19c334d4147d5fcdd4daa2ed6687340a2cd4b0 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Oct 2014 14:12:46 +0200
+Subject: [PATCH 02/13] Use getnameinfo instead of gethostbyaddr
+
+---
+ addrtoname.c | 48 ++++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 46 insertions(+), 2 deletions(-)
+
+diff --git a/addrtoname.c b/addrtoname.c
+index df7c2ce..a1e360d 100644
+--- a/addrtoname.c
++++ b/addrtoname.c
+@@ -230,7 +230,6 @@ static uint32_t f_localnet;
+ const char *
+ getname(netdissect_options *ndo, const u_char *ap)
+ {
+-	register struct hostent *hp;
+ 	uint32_t addr;
+ 	struct hnamemem *p;
+ 
+@@ -252,6 +251,28 @@ getname(netdissect_options *ndo, const u_char *ap)
+ 	 */
+ 	if (!ndo->ndo_nflag &&
+ 	    (addr & f_netmask) == f_localnet) {
++#ifdef HAVE_GETNAMEINFO
++		struct sockaddr_in sa;
++		char hbuf[NI_MAXHOST];
++
++		memset(&sa, 0, sizeof (sa));
++		sa.sin_family = AF_INET;
++		sa.sin_addr.s_addr = addr;
++		if (!getnameinfo((struct sockaddr *)&sa, sizeof (sa),
++					hbuf, sizeof (hbuf), NULL, 0, 0)) {
++			if (ndo->ndo_Nflag) {
++				char *dotp;
++
++				/* Remove domain qualifications */
++				dotp = strchr(hbuf, '.');
++				if (dotp)
++					*dotp = '\0';
++			}
++			p->name = strdup(hbuf);
++			return p->name;
++		}
++#else
++		register struct hostent *hp;
+ 		hp = gethostbyaddr((char *)&addr, 4, AF_INET);
+ 		if (hp) {
+ 			char *dotp;
+@@ -268,6 +289,7 @@ getname(netdissect_options *ndo, const u_char *ap)
+ 			}
+ 			return (p->name);
+ 		}
++#endif
+ 	}
+ 	p->name = strdup(intoa(addr));
+ 	if (p->name == NULL)
+@@ -282,7 +304,6 @@ getname(netdissect_options *ndo, const u_char *ap)
+ const char *
+ getname6(netdissect_options *ndo, const u_char *ap)
+ {
+-	register struct hostent *hp;
+ 	union {
+ 		struct in6_addr addr;
+ 		struct for_hash_addr {
+@@ -307,6 +328,28 @@ getname6(netdissect_options *ndo, const u_char *ap)
+ 	 * Do not print names if -n was given.
+ 	 */
+ 	if (!ndo->ndo_nflag) {
++#ifdef HAVE_GETNAMEINFO
++		struct sockaddr_in6 sa;
++		char hbuf[NI_MAXHOST];
++
++		memset(&sa, 0, sizeof (sa));
++		sa.sin6_family = AF_INET6;
++		sa.sin6_addr = addr.addr;
++		if (!getnameinfo((struct sockaddr *)&sa, sizeof (sa),
++					hbuf, sizeof (hbuf), NULL, 0, 0)) {
++			if (ndo->ndo_Nflag) {
++				char *dotp;
++
++				/* Remove domain qualifications */
++				dotp = strchr(hbuf, '.');
++				if (dotp)
++					*dotp = '\0';
++			}
++			p->name = strdup(hbuf);
++			return p->name;
++		}
++#else
++                register struct hostent *hp;
+ 		hp = gethostbyaddr((char *)&addr, sizeof(addr), AF_INET6);
+ 		if (hp) {
+ 			char *dotp;
+@@ -323,6 +366,7 @@ getname6(netdissect_options *ndo, const u_char *ap)
+ 			}
+ 			return (p->name);
+ 		}
++#endif
+ 	}
+ 	cp = addrtostr6(ap, ntop_buf, sizeof(ntop_buf));
+ 	p->name = strdup(cp);
+-- 
+2.13.5
+

--- a/SOURCES/0003-tcpslice-update-tcpslice-patch-to-1.2a3.patch
+++ b/SOURCES/0003-tcpslice-update-tcpslice-patch-to-1.2a3.patch
@@ -1,0 +1,88 @@
+From 13d7bc17050345bd873da008460f176a7942d05c Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Oct 2014 14:43:04 +0200
+Subject: [PATCH 03/13] tcpslice: update tcpslice patch to 1.2a3
+
+---
+ tcpslice-1.2a3/search.c   | 22 +++++++++++++++-------
+ tcpslice-1.2a3/tcpslice.h | 20 ++++++++++++++++++++
+ 2 files changed, 35 insertions(+), 7 deletions(-)
+
+diff --git a/tcpslice-1.2a3/search.c b/tcpslice-1.2a3/search.c
+index 1e2d051..23aa105 100644
+--- a/tcpslice-1.2a3/search.c
++++ b/tcpslice-1.2a3/search.c
+@@ -53,7 +53,7 @@ static const char rcsid[] =
+ /* Size of a packet header in bytes; easier than typing the sizeof() all
+  * the time ...
+  */
+-#define PACKET_HDR_LEN (sizeof( struct pcap_pkthdr ))
++#define PACKET_HDR_LEN (sizeof( struct pcap_sf_pkthdr ))
+ 
+ extern int snaplen;
+ 
+@@ -111,16 +111,24 @@ reasonable_header( struct pcap_pkthdr *hdr, time_t first_time, time_t last_time
+ static void
+ extract_header( pcap_t *p, u_char *buf, struct pcap_pkthdr *hdr )
+ 	{
+-	memcpy((char *) hdr, (char *) buf, sizeof(struct pcap_pkthdr));
++	struct pcap_sf_pkthdr hdri;
++
++	memcpy((char *) &hdri, (char *) buf, sizeof(struct pcap_sf_pkthdr));
+ 
+ 	if ( pcap_is_swapped( p ) )
+ 		{
+-		hdr->ts.tv_sec = SWAPLONG(hdr->ts.tv_sec);
+-		hdr->ts.tv_usec = SWAPLONG(hdr->ts.tv_usec);
+-		hdr->len = SWAPLONG(hdr->len);
+-		hdr->caplen = SWAPLONG(hdr->caplen);
++		hdr->ts.tv_sec = SWAPLONG(hdri.ts.tv_sec);
++		hdr->ts.tv_usec = SWAPLONG(hdri.ts.tv_usec);
++		hdr->len = SWAPLONG(hdri.len);
++		hdr->caplen = SWAPLONG(hdri.caplen);
++		}
++	else
++		{
++		hdr->ts.tv_sec = hdri.ts.tv_sec;
++		hdr->ts.tv_usec = hdri.ts.tv_usec;
++		hdr->len = hdri.len;
++		hdr->caplen = hdri.caplen;
+ 		}
+-
+ 	/*
+ 	 * From bpf/libpcap/savefile.c:
+ 	 *
+diff --git a/tcpslice-1.2a3/tcpslice.h b/tcpslice-1.2a3/tcpslice.h
+index de4a01c..9dcd1a1 100644
+--- a/tcpslice-1.2a3/tcpslice.h
++++ b/tcpslice-1.2a3/tcpslice.h
+@@ -20,6 +20,26 @@
+  */
+ 
+ 
++#include <time.h>
++/* #include <net/bpf.h> */
++
++/*
++ * This is a timeval as stored in disk in a dumpfile.
++ * It has to use the same types everywhere, independent of the actual
++ * `struct timeval'
++ */
++
++struct pcap_timeval {
++    bpf_int32 tv_sec;           /* seconds */
++    bpf_int32 tv_usec;          /* microseconds */
++};
++
++struct pcap_sf_pkthdr {
++    struct pcap_timeval ts;     /* time stamp */
++    bpf_u_int32 caplen;         /* length of portion present */
++    bpf_u_int32 len;            /* length this packet (off wire) */
++};
++
+ time_t	gwtm2secs( struct tm *tm );
+ 
+ int	sf_find_end( struct pcap *p, struct timeval *first_timestamp,
+-- 
+2.13.5
+

--- a/SOURCES/0004-tcpslice-remove-unneeded-include.patch
+++ b/SOURCES/0004-tcpslice-remove-unneeded-include.patch
@@ -1,0 +1,26 @@
+From fb802b7fe7430d4714731955110678e211f020c8 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Oct 2014 15:06:54 +0200
+Subject: [PATCH 04/13] tcpslice: remove unneeded include
+
+net/bpf.h doesn't exist on Linux.
+---
+ tcpslice-1.2a3/tcpslice.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/tcpslice-1.2a3/tcpslice.c b/tcpslice-1.2a3/tcpslice.c
+index e73d76f..895e54f 100644
+--- a/tcpslice-1.2a3/tcpslice.c
++++ b/tcpslice-1.2a3/tcpslice.c
+@@ -35,8 +35,6 @@ static const char rcsid[] =
+ #include <sys/file.h>
+ #include <sys/stat.h>
+ 
+-#include <net/bpf.h>
+-
+ #include <ctype.h>
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+-- 
+2.13.5
+

--- a/SOURCES/0005-tcpslice-don-t-test-the-pointer-but-pointee-for-NULL.patch
+++ b/SOURCES/0005-tcpslice-don-t-test-the-pointer-but-pointee-for-NULL.patch
@@ -1,0 +1,27 @@
+From e010a585a52c0e4b127190d45cd51b906872f948 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Oct 2014 15:19:44 +0200
+Subject: [PATCH 05/13] tcpslice: don't test the pointer but pointee for NULL
+
+---
+ tcpslice-1.2a3/tcpslice.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tcpslice-1.2a3/tcpslice.c b/tcpslice-1.2a3/tcpslice.c
+index 895e54f..a91439b 100644
+--- a/tcpslice-1.2a3/tcpslice.c
++++ b/tcpslice-1.2a3/tcpslice.c
+@@ -402,7 +402,9 @@ fill_tm(char *time_string, int is_delta, struct tm *t, time_t *usecs_addr)
+ 
+ 		while (isdigit(*t_stop))
+ 			++t_stop;
+-		if (! t_stop)
++
++                if (!(*t_stop))
++                        /* we've reached end of string -> bad date format */
+ 			error("bad date format %s, problem starting at %s",
+ 			      time_string, t_start);
+ 
+-- 
+2.13.5
+

--- a/SOURCES/0006-Introduce-nn-option.patch
+++ b/SOURCES/0006-Introduce-nn-option.patch
@@ -1,0 +1,55 @@
+From d8d7143f1c0ca5a36f7d1f1092d360afbf4e71d3 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Oct 2014 13:26:38 +0200
+Subject: [PATCH 06/13] Introduce -nn option
+
+This changes the semantics on -n option so only namelookups are skipped. Port
+numbers *are* translated to their string representations. Option -nn then has
+the same semantics as -n had originally.
+---
+ addrtoname.c | 4 ++--
+ tcpdump.1.in | 6 +++++-
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/addrtoname.c b/addrtoname.c
+index a1e360d..f8e777c 100644
+--- a/addrtoname.c
++++ b/addrtoname.c
+@@ -822,7 +822,7 @@ init_servarray(netdissect_options *ndo)
+ 
+ 		while (table->name)
+ 			table = table->nxt;
+-		if (ndo->ndo_nflag) {
++		if (ndo->ndo_nflag > 1) {
+ 			(void)snprintf(buf, sizeof(buf), "%d", port);
+ 			table->name = strdup(buf);
+ 		} else
+@@ -1245,7 +1245,7 @@ init_addrtoname(netdissect_options *ndo, uint32_t localnet, uint32_t mask)
+ 		f_localnet = localnet;
+ 		f_netmask = mask;
+ 	}
+-	if (ndo->ndo_nflag)
++	if (ndo->ndo_nflag > 1)
+ 		/*
+ 		 * Simplest way to suppress names.
+ 		 */
+diff --git a/tcpdump.1.in b/tcpdump.1.in
+index 081e5d1..f233934 100644
+--- a/tcpdump.1.in
++++ b/tcpdump.1.in
+@@ -544,7 +544,11 @@ Use \fIsecret\fP as a shared secret for validating the digests found in
+ TCP segments with the TCP-MD5 option (RFC 2385), if present.
+ .TP
+ .B \-n
+-Don't convert addresses (i.e., host addresses, port numbers, etc.) to names.
++Don't convert host addresses to names.  This can be used to avoid
++DNS lookups.
++.TP
++.B \-nn
++Don't convert protocol and port numbers etc. to names either.
+ .TP
+ .B \-N
+ Don't print domain name qualification of host names.
+-- 
+2.13.5
+

--- a/SOURCES/0007-Don-t-print-out-we-dropped-root-we-are-always-droppi.patch
+++ b/SOURCES/0007-Don-t-print-out-we-dropped-root-we-are-always-droppi.patch
@@ -1,0 +1,36 @@
+From f853995b93dd4c533c09ce67647b0cfd4dca6b9b Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Fri, 3 Feb 2017 09:43:03 +0100
+Subject: [PATCH 07/13] Don't print out we dropped root, we are always dropping
+ it
+
+---
+ tcpdump.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/tcpdump.c b/tcpdump.c
+index d9c7f7a..e4e0d89 100644
+--- a/tcpdump.c
++++ b/tcpdump.c
+@@ -609,8 +609,6 @@ droproot(const char *username, const char *chroot_dir)
+ 			int ret = capng_change_id(pw->pw_uid, pw->pw_gid, CAPNG_NO_FLAG);
+ 			if (ret < 0) {
+ 				fprintf(stderr, "error : ret %d\n", ret);
+-			} else {
+-				fprintf(stderr, "dropped privs to %s\n", username);
+ 			}
+ 		}
+ #else
+@@ -623,9 +621,6 @@ droproot(const char *username, const char *chroot_dir)
+ 				pcap_strerror(errno));
+ 			exit_tcpdump(1);
+ 		}
+-		else {
+-			fprintf(stderr, "dropped privs to %s\n", username);
+-		}
+ #endif /* HAVE_LIBCAP_NG */
+ 	}
+ 	else {
+-- 
+2.13.5
+

--- a/SOURCES/0008-Change-P-to-Q-and-print-warning.patch
+++ b/SOURCES/0008-Change-P-to-Q-and-print-warning.patch
@@ -1,0 +1,107 @@
+From 8a60760db57f496c2f893486f245b40560653ccd Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 20 Feb 2017 11:01:19 +0100
+Subject: [PATCH 08/13] Change -P to -Q and print warning
+
+Guy Harris points that -P is already taken by MacOS derived work and
+that the only remaining single-letter option is -Q (see GH #252). Fix
+some formatting while at it.
+---
+ tcpdump.1.in |  4 ++--
+ tcpdump.c    | 23 +++++++++++++----------
+ 2 files changed, 15 insertions(+), 12 deletions(-)
+
+diff --git a/tcpdump.1.in b/tcpdump.1.in
+index f233934..88b1266 100644
+--- a/tcpdump.1.in
++++ b/tcpdump.1.in
+@@ -74,7 +74,7 @@ tcpdump \- dump traffic on a network
+ .B \-\-number
+ ]
+ [
+-.B \-Q
++.B \-Q|\-P
+ .I in|out|inout
+ ]
+ .ti +8
+@@ -583,7 +583,7 @@ Note that the interface might be in promiscuous
+ mode for some other reason; hence, `-p' cannot be used as an abbreviation for
+ `ether host {local-hw-addr} or ether broadcast'.
+ .TP
+-.BI \-Q " direction"
++.BI \-Q|\-P " direction"
+ .PD 0
+ .TP
+ .BI \-\-direction= direction
+diff --git a/tcpdump.c b/tcpdump.c
+index e4e0d89..d7b094b 100644
+--- a/tcpdump.c
++++ b/tcpdump.c
+@@ -157,7 +157,7 @@ static int Jflag;			/* list available time stamp types */
+ static int jflag = -1;			/* packet time stamp source */
+ static int pflag;			/* don't go promiscuous */
+ #ifdef HAVE_PCAP_SETDIRECTION
+-static int Qflag = -1;			/* restrict captured packet by send/receive direction */
++static int PQflag = -1;			/* restrict captured packet by send/receive direction */
+ #endif
+ static int Uflag;			/* "unbuffered" output of dump files */
+ static int Wflag;			/* recycle output files after this number of files */
+@@ -509,12 +509,12 @@ show_devices_and_exit (void)
+ #endif
+ 
+ #ifdef HAVE_PCAP_SETDIRECTION
+-#define Q_FLAG "Q:"
++#define PQ_FLAG "P:Q:"
+ #else
+-#define Q_FLAG
++#define PQ_FLAG
+ #endif
+ 
+-#define SHORTOPTS "aAb" B_FLAG "c:C:d" D_FLAG "eE:fF:G:hHi:" I_FLAG j_FLAG J_FLAG "KlLm:M:nNOpq" Q_FLAG "r:s:StT:u" U_FLAG "vV:w:W:xXy:Yz:Z:#"
++#define SHORTOPTS "aAb" B_FLAG "c:C:d" D_FLAG "eE:fF:G:hHi:" I_FLAG j_FLAG J_FLAG "KlLm:M:nNOpq" PQ_FLAG "r:s:StT:u" U_FLAG "vV:w:W:xXy:Yz:Z:#"
+ 
+ /*
+  * Long options.
+@@ -1059,8 +1059,8 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
+ 			    pcap_statustostr(status));
+ 	}
+ #ifdef HAVE_PCAP_SETDIRECTION
+-	if (Qflag != -1) {
+-		status = pcap_setdirection(pc, Qflag);
++	if (PQflag != -1) {
++		status = pcap_setdirection(pc, PQflag);
+ 		if (status != 0)
+ 			error("%s: pcap_setdirection() failed: %s",
+ 			      device,  pcap_geterr(pc));
+@@ -1343,13 +1343,16 @@ main(int argc, char **argv)
+ 			break;
+ 
+ #ifdef HAVE_PCAP_SETDIRECTION
++                case 'P':
++                        fprintf(stderr, "Warning: -P switch is not compatible with the upstream version. You should use -Q instead.\n");
++                        /* Intentional fall through */
+ 		case 'Q':
+ 			if (ascii_strcasecmp(optarg, "in") == 0)
+-				Qflag = PCAP_D_IN;
++				PQflag = PCAP_D_IN;
+ 			else if (ascii_strcasecmp(optarg, "out") == 0)
+-				Qflag = PCAP_D_OUT;
++				PQflag = PCAP_D_OUT;
+ 			else if (ascii_strcasecmp(optarg, "inout") == 0)
+-				Qflag = PCAP_D_INOUT;
++				PQflag = PCAP_D_INOUT;
+ 			else
+ 				error("unknown capture direction `%s'", optarg);
+ 			break;
+@@ -2613,7 +2616,7 @@ print_usage(void)
+ "\t\t[ -i interface ]" j_FLAG_USAGE " [ -M secret ] [ --number ]\n");
+ #ifdef HAVE_PCAP_SETDIRECTION
+ 	(void)fprintf(stderr,
+-"\t\t[ -Q in|out|inout ]\n");
++"\t\t[ -Q|-P in|out|inout ]\n");
+ #endif
+ 	(void)fprintf(stderr,
+ "\t\t[ -r file ] [ -s snaplen ] ");
+-- 
+2.13.5
+

--- a/SOURCES/0009-Change-n-flag-to-nn-in-TESTonce.patch
+++ b/SOURCES/0009-Change-n-flag-to-nn-in-TESTonce.patch
@@ -1,0 +1,27 @@
+From 04e23aa3f91ff137237daf68f02e7b3c0c1a9168 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Tue, 11 Apr 2017 09:19:48 +0200
+Subject: [PATCH 09/13] Change -n flag to -nn in TESTonce
+
+We need to change this because we have a different meaning of -n
+flag than upstream does. We use -nn in those cases.
+---
+ tests/TESTonce | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/TESTonce b/tests/TESTonce
+index 7026624..e348701 100755
+--- a/tests/TESTonce
++++ b/tests/TESTonce
+@@ -21,7 +21,7 @@ if ($^O eq 'MSWin32') {
+ else {
+     # we used to do this as a nice pipeline, but the problem is that $r fails to
+     # to be set properly if the tcpdump core dumps.
+-    $r = system "../tcpdump 2>/dev/null -n -t -r $input $options >NEW/$output";
++    $r = system "../tcpdump 2>/dev/null -nn -t -r $input $options >NEW/$output";
+     if($r != 0) {
+         # this means tcpdump failed.
+         open(OUTPUT, ">>"."NEW/$output") || die "fail to open $output\n";
+-- 
+2.13.5
+

--- a/SOURCES/0010-Expect-miliseconds-instead-of-seconds-in-icmp-captur.patch
+++ b/SOURCES/0010-Expect-miliseconds-instead-of-seconds-in-icmp-captur.patch
@@ -1,0 +1,46 @@
+From 0ae4aa1881bbe40443bff802b5e4aa6ca0696dd9 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Tue, 11 Apr 2017 09:37:53 +0200
+Subject: [PATCH 10/13] Expect miliseconds instead of seconds in icmp capture.
+
+Again this is caused by our patch, so we need to modify tests
+accordingly.
+---
+ tests/icmpv6.out         | 2 +-
+ tests/icmpv6_opt24-v.out | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/icmpv6.out b/tests/icmpv6.out
+index bb7775e..8979540 100644
+--- a/tests/icmpv6.out
++++ b/tests/icmpv6.out
+@@ -1,5 +1,5 @@
+ IP6 (hlim 255, next-header ICMPv6 (58) payload length: 176) fe80::b299:28ff:fec8:d66c > ff02::1: [icmp6 sum ok] ICMP6, router advertisement, length 176
+-	hop limit 64, Flags [home agent], pref medium, router lifetime 15s, reachable time 0s, retrans time 0s
++	hop limit 64, Flags [home agent], pref medium, router lifetime 15s, reachable time 0ms, retrans time 0ms
+ 	  prefix info option (3), length 32 (4): 2222:3333:4444:5555:6600::/72, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
+ 	    0x0000:  48c0 0027 8d00 0009 3a80 0000 0000 2222
+ 	    0x0010:  3333 4444 5555 6600 0000 0000 0000
+diff --git a/tests/icmpv6_opt24-v.out b/tests/icmpv6_opt24-v.out
+index 2b7cf09..00512df 100644
+--- a/tests/icmpv6_opt24-v.out
++++ b/tests/icmpv6_opt24-v.out
+@@ -1,5 +1,5 @@
+ IP6 (hlim 255, next-header ICMPv6 (58) payload length: 120) fe80::16cf:92ff:fe87:23d6 > ff02::1: [icmp6 sum ok] ICMP6, router advertisement, length 120
+-	hop limit 0, Flags [managed, other stateful], pref medium, router lifetime 0s, reachable time 0s, retrans time 0s
++	hop limit 0, Flags [managed, other stateful], pref medium, router lifetime 0s, reachable time 0ms, retrans time 0ms
+ 	  source link-address option (1), length 8 (1): 14:cf:92:87:23:d6
+ 	  mtu option (5), length 8 (1):  1500
+ 	  prefix info option (3), length 32 (4): fd8d:4fb3:5b2e::/64, Flags [onlink, auto], valid time 7200s, pref. time 1800s
+@@ -7,7 +7,7 @@ IP6 (hlim 255, next-header ICMPv6 (58) payload length: 120) fe80::16cf:92ff:fe87
+ 	  rdnss option (25), length 24 (3):  lifetime 1800s, addr: fd8d:4fb3:5b2e::1
+ 	  dnssl option (31), length 16 (2):  lifetime 1800s, domain(s): lan.
+ IP6 (hlim 255, next-header ICMPv6 (58) payload length: 120) fe80::16cf:92ff:fe87:23d6 > ff02::1: [icmp6 sum ok] ICMP6, router advertisement, length 120
+-	hop limit 0, Flags [managed, other stateful], pref medium, router lifetime 0s, reachable time 0s, retrans time 0s
++	hop limit 0, Flags [managed, other stateful], pref medium, router lifetime 0s, reachable time 0ms, retrans time 0ms
+ 	  source link-address option (1), length 8 (1): 14:cf:92:87:23:d6
+ 	  mtu option (5), length 8 (1):  1500
+ 	  prefix info option (3), length 32 (4): fd8d:4fb3:5b2e::/64, Flags [onlink, auto], valid time 7200s, pref. time 1800s
+-- 
+2.13.5
+

--- a/SOURCES/0011-Disable-tests-that-require-newer-version-of-libpcap.patch
+++ b/SOURCES/0011-Disable-tests-that-require-newer-version-of-libpcap.patch
@@ -1,0 +1,46 @@
+From 5c2c64adef083164bd4f7227905e7da3ec79a203 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Tue, 11 Apr 2017 09:42:57 +0200
+Subject: [PATCH 11/13] Disable tests that require newer version of libpcap.
+
+As can be seen from ltrace:
+pcap_compile(0x25d4250, 0x7ffc966dcba0, "geneve && tcp", 1, nil) = -1
+these two filters (geneve) cannot be compiled, but it is not a tcpdump
+fault.
+---
+ tests/TESTLIST | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/tests/TESTLIST b/tests/TESTLIST
+index bc35a7e..c0f6aff 100644
+--- a/tests/TESTLIST
++++ b/tests/TESTLIST
+@@ -301,8 +301,9 @@ aoe_1-v		AoE_Linux.pcap		aoe_1-v.out	-v
+ 
+ # Geneve tests
+ geneve-v	geneve.pcap		geneve-vv.out	-vv
+-geneve-vni	geneve.pcap		geneve-vni.out	geneve 0xb
+-geneve-tcp	geneve.pcap		geneve-tcp.out	"geneve && tcp"
++# These filters cannot be compiled by our libpcap
++# geneve-vni	geneve.pcap		geneve-vni.out	geneve 0xb
++# geneve-tcp	geneve.pcap		geneve-tcp.out	"geneve && tcp"
+ 
+ # DHCP tests
+ dhcp-rfc3004	dhcp-rfc3004.pcap	dhcp-rfc3004-v.out	-v
+@@ -356,11 +357,11 @@ lisp_ipv6_eid		lisp_ipv6.pcap		lisp_ipv6.out		-v
+ 
+ # pcap invalid versions (first: version = 1.4 ; second: version = 2.5)
+ pcap-invalid-version-1 pcap-invalid-version-1.pcap pcap-invalid-version-1.out
+-pcap-invalid-version-2 pcap-invalid-version-2.pcap pcap-invalid-version-2.out
++# pcap-invalid-version-2 pcap-invalid-version-2.pcap pcap-invalid-version-2.out
+ 
+ # pcap-ng invalid version (first: version = 0.1 ; second: version = 1.1)
+ pcap-ng-invalid-vers-1 pcap-ng-invalid-vers-1.pcap pcap-ng-invalid-vers-1.out
+-pcap-ng-invalid-vers-2 pcap-ng-invalid-vers-2.pcap pcap-ng-invalid-vers-2.out
++# pcap-ng-invalid-vers-2 pcap-ng-invalid-vers-2.pcap pcap-ng-invalid-vers-2.out
+ 
+ # NSH over VxLAN-GPE
+ nsh-over-vxlan-gpe     nsh-over-vxlan-gpe.pcap nsh-over-vxlan-gpe.out
+-- 
+2.13.5
+

--- a/SOURCES/0012-Make-default-capture-buffer-size-bigger.patch
+++ b/SOURCES/0012-Make-default-capture-buffer-size-bigger.patch
@@ -1,0 +1,39 @@
+From 41d5020151d21ff0609a4c4173ef2a8ae41f754d Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Tue, 9 May 2017 10:17:42 +0200
+Subject: [PATCH 12/13] Make default capture buffer size bigger.
+
+---
+ tcpdump.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/tcpdump.c b/tcpdump.c
+index d7b094b..a54a42c 100644
+--- a/tcpdump.c
++++ b/tcpdump.c
+@@ -130,6 +130,7 @@ The Regents of the University of California.  All rights reserved.\n";
+ #endif
+ 
+ static int Bflag;			/* buffer size */
++#define DEFAULT_CAPTURE_BUFFER_SIZE 4*1024*1024
+ static long Cflag;			/* rotate dump files after this many bytes */
+ static int Cflag_count;			/* Keep track of which file number we're writing */
+ static int Dflag;			/* list available devices and exit */
+@@ -1011,7 +1012,13 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
+ 		if (status != 0)
+ 			error("%s: Can't set buffer size: %s",
+ 			    device, pcap_statustostr(status));
+-	}
++	} else {
++                Bflag = DEFAULT_CAPTURE_BUFFER_SIZE;
++		status = pcap_set_buffer_size(pc, Bflag);
++		if (status != 0)
++                        fprintf(stderr, "Can't set buffer size to %d, using system default.\n", DEFAULT_CAPTURE_BUFFER_SIZE);
++        }
++
+ #ifdef HAVE_PCAP_SET_TSTAMP_TYPE
+ 	if (jflag != -1) {
+ 		status = pcap_set_tstamp_type(pc, jflag);
+-- 
+2.13.5
+

--- a/SOURCES/0013-Add-printing-support-for-vsockmon-devices.patch
+++ b/SOURCES/0013-Add-printing-support-for-vsockmon-devices.patch
@@ -1,0 +1,318 @@
+From 66a5b93dee386bc2f57033a150341752923b8b41 Mon Sep 17 00:00:00 2001
+From: Gerard Garcia <ggarcia@deic.uab.cat>
+Date: Tue, 14 Jun 2016 16:45:44 +0200
+Subject: [PATCH 13/13] Add printing support for vsockmon devices.
+
+Print Linux 4.12 vsockmon captures:
+
+  # modprobe vsockmon
+  # ip link add type vsockmon
+  # ip link set vsockmon0 up
+  # tcpdump -i vsockmon0
+  16:25:24.987917 VIRTIO 3.1025 > 2.1234 CONNECT, length 76
+  16:25:24.987963 VIRTIO 2.1234 > 3.1025 CONNECT, length 76
+  16:25:26.568271 VIRTIO 3.1025 > 2.1234 PAYLOAD, length 82
+  16:25:26.568512 VIRTIO 2.1234 > 3.1025 CONTROL, length 76
+  16:25:28.411335 VIRTIO 3.1025 > 2.1234 DISCONNECT, length 76
+  16:25:28.411628 VIRTIO 2.1234 > 3.1025 DISCONNECT, length 76
+
+For more information about vsock see:
+http://wiki.qemu.org/Features/VirtioVsock
+---
+ Makefile.in   |   1 +
+ netdissect.h  |   1 +
+ print-vsock.c | 243 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ print.c       |   3 +
+ 4 files changed, 248 insertions(+)
+ create mode 100644 print-vsock.c
+
+diff --git a/Makefile.in b/Makefile.in
+index 0941f0e..a301878 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -226,6 +226,7 @@ LIBNETDISSECT_SRC=\
+ 	print-vjc.c \
+ 	print-vqp.c \
+ 	print-vrrp.c \
++	print-vsock.c \
+ 	print-vtp.c \
+ 	print-vxlan.c \
+ 	print-vxlan-gpe.c \
+diff --git a/netdissect.h b/netdissect.h
+index 089b040..c89fcf1 100644
+--- a/netdissect.h
++++ b/netdissect.h
+@@ -444,6 +444,7 @@ extern u_int symantec_if_print IF_PRINTER_ARGS;
+ extern u_int token_if_print IF_PRINTER_ARGS;
+ extern u_int usb_linux_48_byte_print IF_PRINTER_ARGS;
+ extern u_int usb_linux_64_byte_print IF_PRINTER_ARGS;
++extern u_int vsock_print IF_PRINTER_ARGS;
+ 
+ /*
+  * Structure passed to some printers to allow them to print
+diff --git a/print-vsock.c b/print-vsock.c
+new file mode 100644
+index 0000000..fc5694d
+--- /dev/null
++++ b/print-vsock.c
+@@ -0,0 +1,243 @@
++/*
++ * Copyright (c) 2016 Gerard Garcia <nouboh@gmail.com>
++ * Copyright (c) 2017 Red Hat, Inc.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ *   1. Redistributions of source code must retain the above copyright
++ *      notice, this list of conditions and the following disclaimer.
++ *   2. Redistributions in binary form must reproduce the above copyright
++ *      notice, this list of conditions and the following disclaimer in
++ *      the documentation and/or other materials provided with the
++ *      distribution.
++ *   3. The names of the authors may not be used to endorse or promote
++ *      products derived from this software without specific prior
++ *      written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
++ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
++ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++ */
++
++/* \summary: Linux vsock printer */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include <netdissect-stdinc.h>
++#include <stddef.h>
++
++#include "netdissect.h"
++#include "extract.h"
++
++static const char tstr[] = " [|vsock]";
++
++enum af_vsockmon_transport {
++	AF_VSOCK_TRANSPORT_UNKNOWN = 0,
++	AF_VSOCK_TRANSPORT_NO_INFO = 1,		/* No transport information */
++	AF_VSOCK_TRANSPORT_VIRTIO = 2,		/* Virtio transport header */
++};
++
++static const struct tok vsock_transport[] = {
++	{AF_VSOCK_TRANSPORT_UNKNOWN, "UNKNOWN"},
++	{AF_VSOCK_TRANSPORT_NO_INFO, "NO_INFO"},
++	{AF_VSOCK_TRANSPORT_VIRTIO, "VIRTIO"},
++	{ 0, NULL }
++};
++
++enum af_vsockmon_op {
++	AF_VSOCK_OP_UNKNOWN = 0,
++	AF_VSOCK_OP_CONNECT = 1,
++	AF_VSOCK_OP_DISCONNECT = 2,
++	AF_VSOCK_OP_CONTROL = 3,
++	AF_VSOCK_OP_PAYLOAD = 4,
++};
++
++static const struct tok vsock_op[] = {
++	{AF_VSOCK_OP_UNKNOWN, "UNKNOWN"},
++	{AF_VSOCK_OP_CONNECT, "CONNECT"},
++	{AF_VSOCK_OP_DISCONNECT, "DISCONNECT"},
++	{AF_VSOCK_OP_CONTROL, "CONTROL"},
++	{AF_VSOCK_OP_PAYLOAD, "PAYLOAD"},
++	{ 0, NULL }
++};
++
++enum virtio_vsock_type {
++	VIRTIO_VSOCK_TYPE_STREAM = 1,
++};
++
++static const struct tok virtio_type[] = {
++	{VIRTIO_VSOCK_TYPE_STREAM, "STREAM"},
++	{ 0, NULL }
++};
++
++enum virtio_vsock_op {
++	VIRTIO_VSOCK_OP_INVALID = 0,
++	VIRTIO_VSOCK_OP_REQUEST = 1,
++	VIRTIO_VSOCK_OP_RESPONSE = 2,
++	VIRTIO_VSOCK_OP_RST = 3,
++	VIRTIO_VSOCK_OP_SHUTDOWN = 4,
++	VIRTIO_VSOCK_OP_RW = 5,
++	VIRTIO_VSOCK_OP_CREDIT_UPDATE = 6,
++	VIRTIO_VSOCK_OP_CREDIT_REQUEST = 7,
++};
++
++static const struct tok virtio_op[] = {
++	{VIRTIO_VSOCK_OP_INVALID, "INVALID"},
++	{VIRTIO_VSOCK_OP_REQUEST, "REQUEST"},
++	{VIRTIO_VSOCK_OP_RESPONSE, "RESPONSE"},
++	{VIRTIO_VSOCK_OP_RST, "RST"},
++	{VIRTIO_VSOCK_OP_SHUTDOWN, "SHUTDOWN"},
++	{VIRTIO_VSOCK_OP_RW, "RW"},
++	{VIRTIO_VSOCK_OP_CREDIT_UPDATE, "CREDIT UPDATE"},
++	{VIRTIO_VSOCK_OP_CREDIT_REQUEST, "CREDIT REQUEST"},
++	{ 0, NULL }
++};
++
++/* All fields are little-endian */
++
++struct virtio_vsock_hdr {
++	uint64_t	src_cid;
++	uint64_t	dst_cid;
++	uint32_t	src_port;
++	uint32_t	dst_port;
++	uint32_t	len;
++	uint16_t	type;		/* enum virtio_vsock_type */
++	uint16_t	op;		/* enum virtio_vsock_op */
++	uint32_t	flags;
++	uint32_t	buf_alloc;
++	uint32_t	fwd_cnt;
++} UNALIGNED;
++
++struct af_vsockmon_hdr {
++	uint64_t src_cid;
++	uint64_t dst_cid;
++	uint32_t src_port;
++	uint32_t dst_port;
++	uint16_t op;		/* enum af_vsockmon_op */
++	uint16_t transport;	/* enum af_vosckmon_transport */
++	uint16_t len;		/* size of transport header */
++	uint8_t reserved[2];
++};
++
++static void
++vsock_virtio_hdr_print(netdissect_options *ndo, const struct virtio_vsock_hdr *hdr)
++{
++	uint16_t u16_v;
++	uint32_t u32_v;
++
++	u32_v = EXTRACT_LE_32BITS(&hdr->len);
++	ND_PRINT((ndo, "len %u", u32_v));
++
++	u16_v = EXTRACT_LE_16BITS(&hdr->type);
++	ND_PRINT((ndo, ", type %s",
++		  tok2str(virtio_type, "Invalid type (%hu)", u16_v)));
++
++	u16_v = EXTRACT_LE_16BITS(&hdr->op);
++	ND_PRINT((ndo, ", op %s",
++		  tok2str(virtio_op, "Invalid op (%hu)", u16_v)));
++
++	u32_v = EXTRACT_LE_32BITS(&hdr->flags);
++	ND_PRINT((ndo, ", flags %x", u32_v));
++
++	u32_v = EXTRACT_LE_32BITS(&hdr->buf_alloc);
++	ND_PRINT((ndo, ", buf_alloc %u", u32_v));
++
++	u32_v = EXTRACT_LE_32BITS(&hdr->fwd_cnt);
++	ND_PRINT((ndo, ", fwd_cnt %u", u32_v));
++}
++
++static size_t
++vsock_transport_hdr_size(uint16_t transport)
++{
++	switch (transport) {
++		case AF_VSOCK_TRANSPORT_VIRTIO:
++			return sizeof(struct virtio_vsock_hdr);
++		default:
++			return 0;
++	}
++}
++
++static void
++vsock_transport_hdr_print(netdissect_options *ndo, uint16_t transport,
++                          const u_char *p, const u_int len)
++{
++	size_t transport_size = vsock_transport_hdr_size(transport);
++	const void *hdr;
++
++	if (len < sizeof(struct af_vsockmon_hdr) + transport_size)
++		return;
++
++	hdr = p + sizeof(struct af_vsockmon_hdr);
++	switch (transport) {
++		case AF_VSOCK_TRANSPORT_VIRTIO:
++			ND_PRINT((ndo, " ("));
++			vsock_virtio_hdr_print(ndo, hdr);
++			ND_PRINT((ndo, ")"));
++			break;
++		default:
++			break;
++	}
++}
++
++static void
++vsock_hdr_print(netdissect_options *ndo, const u_char *p, const u_int len)
++{
++	uint16_t hdr_transport, hdr_op;
++	uint32_t hdr_src_port, hdr_dst_port;
++	uint64_t hdr_src_cid, hdr_dst_cid;
++	size_t total_hdr_size;
++
++	const struct af_vsockmon_hdr *hdr = (struct af_vsockmon_hdr *)p;
++
++	hdr_transport = EXTRACT_LE_16BITS(&hdr->transport);
++	ND_PRINT((ndo, "%s",
++		  tok2str(vsock_transport, "Invalid transport (%u)",
++			  hdr_transport)));
++
++	/* If verbose level is more than 0 print transport details */
++	if (ndo->ndo_vflag) {
++		vsock_transport_hdr_print(ndo, hdr_transport, p, len);
++		ND_PRINT((ndo, "\n\t"));
++	} else
++		ND_PRINT((ndo, " "));
++
++	hdr_src_cid = EXTRACT_LE_64BITS(&hdr->src_cid);
++	hdr_dst_cid = EXTRACT_LE_64BITS(&hdr->dst_cid);
++	hdr_src_port = EXTRACT_LE_32BITS(&hdr->src_port);
++	hdr_dst_port = EXTRACT_LE_32BITS(&hdr->dst_port);
++	hdr_op = EXTRACT_LE_16BITS(&hdr->op);
++	ND_PRINT((ndo, "%lu.%hu > %lu.%hu %s, length %u",
++		  hdr_src_cid, hdr_src_port,
++		  hdr_dst_cid, hdr_dst_port,
++		  tok2str(vsock_op, " invalid op (%u)", hdr_op),
++		  len));
++
++	/* If debug level is more than 1 print payload contents */
++	total_hdr_size = sizeof(struct af_vsockmon_hdr) +
++			 vsock_transport_hdr_size(hdr_transport);
++	if (ndo->ndo_vflag > 1 &&
++	    hdr_op == AF_VSOCK_OP_PAYLOAD &&
++	    len > total_hdr_size) {
++		const u_char *payload = p + total_hdr_size;
++
++		ND_PRINT((ndo, "\n"));
++		print_unknown_data(ndo, payload, "\t", len - total_hdr_size);
++	}
++}
++
++u_int
++vsock_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char *cp)
++{
++	u_int len = h->len;
++
++	if (len < sizeof(struct af_vsockmon_hdr))
++		ND_PRINT((ndo, "%s", tstr));
++	else
++		vsock_hdr_print(ndo, cp, len);
++
++	return len;
++}
+diff --git a/print.c b/print.c
+index c76f344..1945cfd 100644
+--- a/print.c
++++ b/print.c
+@@ -220,6 +220,9 @@ static const struct printer printers[] = {
+ #ifdef DLT_PPP_SERIAL
+ 	{ ppp_hdlc_if_print,	DLT_PPP_SERIAL },
+ #endif
++#ifdef DLT_VSOCK
++	{ vsock_print,		DLT_VSOCK },
++#endif
+ 	{ NULL,			0 },
+ };
+ 
+-- 
+2.13.5
+

--- a/SOURCES/0014-Disable-test-with-unsupported-link-type.patch
+++ b/SOURCES/0014-Disable-test-with-unsupported-link-type.patch
@@ -1,0 +1,26 @@
+From b7a5a890eb36c562ed0a5196985120348b35b4e0 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Thu, 14 Sep 2017 12:56:02 +0200
+Subject: [PATCH] Disable test with unsupported link type
+
+---
+ tests/TESTLIST | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tests/TESTLIST b/tests/TESTLIST
+index c0f6aff..0c4c2c9 100644
+--- a/tests/TESTLIST
++++ b/tests/TESTLIST
+@@ -503,7 +503,8 @@ juniper_es		juniper_es.pcap			juniper_es.out	-vvv -e
+ 
+ # bad packets from Yannick Formaggio
+ l2tp-avp-overflow	l2tp-avp-overflow.pcap		l2tp-avp-overflow.out	-v
+-pktap-heap-overflow	pktap-heap-overflow.pcap	pktap-heap-overflow.out	-v
++# This link type is not supported by RHEL7's libpcap
++# pktap-heap-overflow	pktap-heap-overflow.pcap	pktap-heap-overflow.out	-v
+ wb-oobr			wb-oobr.pcap			wb-oobr.out	-v
+ 
+ # bad packets from Bhargava Shastry
+-- 
+2.13.5
+

--- a/SOURCES/tcpdump-4.9.2.tar.gz
+++ b/SOURCES/tcpdump-4.9.2.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:798b3536a29832ce0cbb07fafb1ce5097c95e308a6f592d14052e1ef1505fe79
+size 2298386

--- a/SOURCES/tcpslice-1.2a3.tar.gz
+++ b/SOURCES/tcpslice-1.2a3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4096e8debc898cfaa16b5306f1c42f8d18b19e30e60da8d4deb781c8f684c840
+size 76879

--- a/SPECS/tcpdump.spec
+++ b/SPECS/tcpdump.spec
@@ -2,12 +2,13 @@ Summary: A network traffic monitoring tool
 Name: tcpdump
 Epoch: 14
 Version: 4.9.2
-Release: 3%{?dist}
+Release: 3.1%{?dist}
 License: BSD with advertising
 URL: http://www.tcpdump.org
 Group: Applications/Internet
 Requires(pre): shadow-utils
 Requires: libpcap >= 14:1.5.3-10
+BuildRequires: gcc
 BuildRequires: automake sharutils openssl-devel libcap-ng-devel libpcap-devel git 
 
 Source0: http://www.tcpdump.org/release/%{name}-%{version}.tar.gz
@@ -89,6 +90,10 @@ exit 0
 %{_mandir}/man8/tcpdump.8*
 
 %changelog
+* Tue Jan 20 2026 Philippe Coval <philippe.coval@vates.tech> - 14:4.9.2-3.1
+- Add gcc to BuildRequires
+- Rebuild for openssl-3
+
 * Wed Nov 15 2017 Michal Ruprich - 14:4.9.2-3
 - Related: rhbz#1464390; build against latest libpcap
 

--- a/SPECS/tcpdump.spec
+++ b/SPECS/tcpdump.spec
@@ -1,0 +1,668 @@
+Summary: A network traffic monitoring tool
+Name: tcpdump
+Epoch: 14
+Version: 4.9.2
+Release: 3%{?dist}
+License: BSD with advertising
+URL: http://www.tcpdump.org
+Group: Applications/Internet
+Requires(pre): shadow-utils
+Requires: libpcap >= 14:1.5.3-10
+BuildRequires: automake sharutils openssl-devel libcap-ng-devel libpcap-devel git 
+
+Source0: http://www.tcpdump.org/release/%{name}-%{version}.tar.gz
+Source1: ftp://ftp.ee.lbl.gov/tcpslice-1.2a3.tar.gz
+
+Patch0001:	0001-icmp6-print-Reachable-Time-and-Retransmit-Time-from-.patch
+Patch0002:	0002-Use-getnameinfo-instead-of-gethostbyaddr.patch
+Patch0003:	0003-tcpslice-update-tcpslice-patch-to-1.2a3.patch
+Patch0004:	0004-tcpslice-remove-unneeded-include.patch
+Patch0005:	0005-tcpslice-don-t-test-the-pointer-but-pointee-for-NULL.patch
+Patch0006:	0006-Introduce-nn-option.patch
+Patch0007:	0007-Don-t-print-out-we-dropped-root-we-are-always-droppi.patch
+Patch0008:	0008-Change-P-to-Q-and-print-warning.patch
+Patch0009:	0009-Change-n-flag-to-nn-in-TESTonce.patch
+Patch0010:	0010-Expect-miliseconds-instead-of-seconds-in-icmp-captur.patch
+Patch0011:	0011-Disable-tests-that-require-newer-version-of-libpcap.patch
+Patch0012:	0012-Make-default-capture-buffer-size-bigger.patch
+Patch0013:	0013-Add-printing-support-for-vsockmon-devices.patch
+Patch0014:	0014-Disable-test-with-unsupported-link-type.patch
+
+%define tcpslice_dir tcpslice-1.2a3
+
+%description
+Tcpdump is a command-line tool for monitoring network traffic.
+Tcpdump can capture and display the packet headers on a particular
+network interface or on all interfaces.  Tcpdump can display all of
+the packet headers, or just the ones that match particular criteria.
+
+Install tcpdump if you need a program to monitor network traffic.
+
+%prep
+%autosetup -a 1 -S git
+
+%build
+export CFLAGS="$RPM_OPT_FLAGS $(getconf LFS_CFLAGS) -fno-strict-aliasing -DHAVE_GETNAMEINFO"
+
+pushd %{tcpslice_dir}
+# update config.{guess,sub}
+automake -a -f 2> /dev/null || :
+%configure
+make %{?_smp_mflags}
+popd
+
+%configure --with-crypto --with-user=tcpdump --without-smi
+make %{?_smp_mflags}
+
+%check
+make check
+
+%install
+mkdir -p ${RPM_BUILD_ROOT}%{_libdir}
+mkdir -p ${RPM_BUILD_ROOT}%{_mandir}/man8
+mkdir -p ${RPM_BUILD_ROOT}%{_sbindir}
+
+pushd %{tcpslice_dir}
+install -m755 tcpslice ${RPM_BUILD_ROOT}%{_sbindir}
+install -m644 tcpslice.1 ${RPM_BUILD_ROOT}%{_mandir}/man8/tcpslice.8
+popd
+
+install -m755 tcpdump ${RPM_BUILD_ROOT}%{_sbindir}
+install -m644 tcpdump.1 ${RPM_BUILD_ROOT}%{_mandir}/man8/tcpdump.8
+
+# fix section numbers
+sed -i 's/\(\.TH[a-zA-Z ]*\)[1-9]\(.*\)/\18\2/' \
+	${RPM_BUILD_ROOT}%{_mandir}/man8/*
+
+%pre
+/usr/sbin/groupadd -g 72 tcpdump 2> /dev/null
+/usr/sbin/useradd -u 72 -g 72 -s /sbin/nologin -M -r \
+	-d / tcpdump 2> /dev/null
+exit 0
+
+%files
+%defattr(-,root,root)
+%doc LICENSE README.md CHANGES CREDITS
+%{_sbindir}/tcpdump
+%{_sbindir}/tcpslice
+%{_mandir}/man8/tcpslice.8*
+%{_mandir}/man8/tcpdump.8*
+
+%changelog
+* Wed Nov 15 2017 Michal Ruprich - 14:4.9.2-3
+- Related: rhbz#1464390; build against latest libpcap
+
+* Mon Nov 13 2017 Michal Ruprich <mruprich@redhat.com> - 14:4.9.2-2
+- Related: rhbz#1464390; added dependency on libpcap-14:1.5.3-10 due to vsockmon support
+
+* Thu Sep 14 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.9.2-1
+- Resolves: rhbz#1490842; Rebase to 4.9.2 version
+
+* Tue Aug 15 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.9.0-6
+- Resolves: rhbz#1464390; Add printing support for vsockmon devices
+
+* Tue May 09 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.9.0-5
+- Resolves: #1441597; use bigger capture buffer than in upstream
+
+* Thu Apr 20 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.9.0-4
+- Drop downstream patch (drop root privileges)
+- Add libcap-ng as a new build dependency
+- Related: #1262283
+
+* Tue Apr 11 2017 root - 14:4.9.0-3
+- Fix tests according to our patches and libpcap version
+
+* Fri Mar 17 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.9.0-2
+- Use getnameinfo instead of gethostbyaddr
+
+* Mon Feb 20 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.9.0-1
+- New upstream version 4.9.0. Resolves: #1422473
+- Add legacy -P switch with warning. Related to #1422473 and #1292056
+
+* Wed Jan 04 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.5.1-6
+- Drop root before creating any dump file. Resolves: #1262283
+
+* Wed Jan 04 2017 Martin Sehnoutka <msehnout@redhat.com> - 14:4.5.1-5
+- Use -Q instead of -P to set capture direction. Resolves: #1292056
+
+* Fri Dec 09 2016 Martin Sehnoutka <msehnout@redhat.com> - 14:4.5.1-4
+- Fix segfault with --help option. Resolves: #1297812
+
+* Thu Jun 18 2015 Michal Sekletar <msekleta@redhat.com> - 14:4.5.1-3
+- add support for nano second timestamps (#1151406)
+- fix cdp dissector, allow zero-length data frames (#1231246)
+
+* Fri Jan 24 2014 Daniel Mach <dmach@redhat.com> - 14:4.5.1-2
+- Mass rebuild 2014-01-24
+
+* Wed Jan 15 2014 Michal Sekletar <msekleta@redhat.com> - 14:4.5.1-1
+- update to 4.5.1
+
+* Fri Dec 27 2013 Daniel Mach <dmach@redhat.com> - 14:4.5.0-2.20131108gitb07944a
+- Mass rebuild 2013-12-27
+
+* Fri Nov 08 2013 Michal Sekletar <msekleta@redhat.com> - 14:4.5.0-1.20131108gitb07944a
+- update to snaphot gitb07944a (#1026855)
+- don't try to change ownership of stdout (#1015767)
+
+* Thu Jun 06 2013 Michal Sekletar <msekleta@redhat.com> - 14:4.4.0-1
+- update to 4.4.0
+
+* Fri Feb 15 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 14:4.3.0-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Sat Jul 21 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 14:4.3.0-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Wed Jun 13 2012 Michal Sekletar <msekleta@redhat.com> - 14:4.3.0-1
+- Update to 4.3.0
+
+* Wed May 16 2012 Michal Sekletar <msekleta@redhat.com>
+- Resolves: #809638
+- created savefile has proper owner
+
+* Sat Jan 14 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 14:4.2.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Tue Jan 03 2012 Jan Synáček <jsynacek@redhat.com> - 14:4.2.1-1
+- Update to 4.2.1
+- Remove ppi.h from sources (readded again in upstream tarball)
+
+* Thu Dec 02 2011 Michal Sekletar <msekleta@redhat.com> - 14:4.2.0-1
+- updated to 4.2.0
+- added new source file ppi.h, missing in upstream tarball
+- disabled make check because of missing .pcap files in testsuite
+- dropped unnecessary patches
+
+* Wed Aug 24 2011 Michal Sekletar <msekleta@redhat.com> - 14:4.1.1-3
+- Fix manpage (#663739)
+- Fix improper handling of bad date format in tcpslice (#684005)
+- Spec file clean up
+
+* Wed Feb 09 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 14:4.1.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Tue Apr 06 2010 Miroslav Lichvar <mlichvar@redhat.com> - 14:4.1.1-1
+- update to 4.1.1
+- add %%check
+
+* Wed Sep 23 2009 Miroslav Lichvar <mlichvar@redhat.com> - 14:4.0.0-3.20090921gitdf3cb4
+- update to snapshot 20090921gitdf3cb4
+
+* Fri Aug 21 2009 Tomas Mraz <tmraz@redhat.com> - 14:4.0.0-2.20090818git832d2c
+- rebuilt with new openssl
+
+* Thu Aug 20 2009 Miroslav Lichvar <mlichvar@redhat.com> - 14:4.0.0-1.20090818git832d2c
+- update to post 4.0.0 git snapshot 20090818git832d2c
+- print retrans and reachable times in ICMPv6 as milliseconds (#474264)
+
+* Sun Jul 26 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 14:3.9.8-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_12_Mass_Rebuild
+
+* Wed Feb 25 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 14:3.9.8-8
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_11_Mass_Rebuild
+
+* Tue Jan 20 2009 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.8-7
+- rebuild for new openssl
+- convert CREDITS to UTF-8 (#226481)
+
+* Fri Aug 29 2008 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.8-6
+- rediff patches with fuzz
+- add -fno-strict-aliasing to CFLAGS
+
+* Mon Jun 02 2008 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.8-5
+- update config.{guess,sub} when building tcpslice
+- remove -D_GNU_SOURCE from CFLAGS
+- disable libsmi check in configure
+
+* Wed Feb 13 2008 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.8-4
+- fix building with new glibc headers
+
+* Thu Dec 06 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.8-3
+- update IKEv2 support
+
+* Thu Dec  6 2007 Jeremy Katz <katzj@redhat.com> - 14:3.9.8-2
+- rebuild for new openssl
+
+* Wed Oct 24 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.8-1
+- update to 3.9.8
+- don't use gethostbyaddr
+- fix default user in man page
+
+* Tue Sep 18 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.7-5
+- support decoding IKEv2 packets
+
+* Wed Aug 22 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.7-4
+- rebuild
+
+* Thu Aug 09 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.7-3
+- enable crypto support on 64-bit architectures
+- update license tag
+
+* Wed Jul 25 2007 Jeremy Katz <katzj@redhat.com> - 14:3.9.7-2
+- rebuild for toolchain bug
+
+* Tue Jul 24 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.7-1
+- update to 3.9.7
+- with -C option, drop root privileges before opening first savefile (#244860)
+- update tcpslice to 1.2a3
+- include time patch from Debian to fix tcpslice on 64-bit architectures
+
+* Thu Mar 15 2007 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.5-3
+- fix buffer overflow in 802.11 printer (#232349, CVE-2007-1218)
+- spec cleanup (#226481)
+
+* Tue Dec 12 2006 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.5-2
+- use tcpdump user, fix scriptlet (#219268)
+
+* Wed Nov 29 2006 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.5-1
+- split off libpcap and arpwatch (#193657)
+- update to 3.9.5
+- force linking with system libpcap
+
+* Fri Nov 17 2006 Miroslav Lichvar <mlichvar@redhat.com> - 14:3.9.4-9
+- fix processing of Prism and AVS headers (#206686)
+- fix arp2ethers script
+- update ethercodes.dat
+- move pcap man page to devel package
+
+* Wed Jul 12 2006 Jesse Keating <jkeating@redhat.com> - 14:3.9.4-8.1
+- rebuild
+
+* Thu Jun 22 2006 Martin Stransky <stransky@redhat.com> - 14:3.9.4-8
+- more ipv6 flags
+
+* Sun Jun  4 2006 Jeremy Katz <katzj@redhat.com> - 14:3.9.4-7
+- fix libpcap-devel inclusion of .so and its deps (#193189)
+
+* Thu Jun 1 2006 Martin Stransky <stransky@redhat.com> - 14:3.9.4-6
+- added release to arpwatch package name
+
+* Wed May 31 2006 Martin Stransky <stransky@redhat.com> - 14:3.9.4-5
+- removed libpcap-devel dependency from libpcap
+
+* Mon May 29 2006 Martin Stransky <stransky@redhat.com> - 14:3.9.4-4
+- added libpcap-devel package (#193189)
+
+* Tue Mar 28 2006 Martin Stransky <stransky@redhat.com> - 14:3.9.4-3
+- updated ethernet codes (#186633)
+
+* Fri Feb 10 2006 Jesse Keating <jkeating@redhat.com> - 14:3.9.4-2.2
+- bump again for double-long bug on ppc(64)
+
+* Tue Feb 07 2006 Jesse Keating <jkeating@redhat.com> - 14:3.9.4-2.1
+- rebuilt for new gcc4.1 snapshot and glibc changes
+
+* Tue Dec 20 2005 Martin Stransky <stransky@redhat.com> - 14:3.9.4-2
+- fix for #176010 - file owner problem when using 'ring buffer
+
+* Fri Dec 09 2005 Jesse Keating <jkeating@redhat.com>
+- rebuilt
+
+* Thu Nov 10 2005 Martin Stransky <stransky@redhat.com> - 14:3.9.4-1
+- new upstream
+
+* Thu Nov 10 2005 Tomas Mraz <tmraz@redhat.com> - 14:3.9.3-5
+- rebuilt against new openssl
+
+* Wed Nov  9 2005 Martin Stransky <stransky@redhat.com> - 14:3.9.3-4
+- rebuilt
+
+* Tue Aug  9 2005 Jeremy Katz <katzj@redhat.com> - 14:3.9.3-3
+- remove explicit kernel dep for libpcap too
+
+* Tue Jul 26 2005 Martin Stransky <stransky@redhat.com> - 14:3.9.3-2
+- fixed typo in last patch
+
+* Tue Jul 26 2005 Martin Stransky <stransky@redhat.com> - 14:3.9.3-1
+- New upstream version - 3.9.3
+- fix for #164227 (buffer overflow)
+- fix for #164230 (missing debug info)
+
+* Tue Jul 14 2005 Martin Stransky <stransky@redhat.com> - 14:3.9.1-1
+- New upstream version
+
+* Tue Jun 21 2005 Martin Stransky <stransky@redhat.com> - 14:3.8.2-14
+- add shadow-utils to Prereq (#160643)
+
+* Tue Jun  7 2005 Martin Stransky <stransky@redhat.com> - 14:3.8.2-13
+- fix for CAN-2005-1267 - BGP DoS, #159209
+
+* Thu Apr 28 2005 Martin Stransky <stransky@redhat.com> - 14:3.8.2-12
+- fix for CAN-2005-1280 Multiple DoS issues in tcpdump
+  (CAN-2005-1279 CAN-2005-1278), #156041
+
+* Mon Mar 7 2005 Martin Stransky <stransky@redhat.com>
+- rebuilt
+
+* Mon Feb 14 2005 Martin Stransky <stransky@redhat.com> - 14:3.8.2-10
+- remove explicit kernel dependecy (#146165)
+- support for files larger than 2GB (#147840)
+
+* Fri Feb 11 2005 Ivana Varekova <varekova@redhat.com> - 14:3.8.2-9
+- added arpsnmp options to specify sender and recipient
+  and corrected arpwatch and arpsnmp man pages (#70386)
+
+* Thu Feb 10 2005 Ivana Varekova <varekova@redhat.com> - 14:3.8.2-8
+- rebuilt
+
+* Wed Oct 12 2004 Harald Hoyer <harald@redhat.com> - 14:3.8.2-7
+- fixed nfs protocol parsing for 64 bit architectures (bug 132781)
+
+* Wed Sep 15 2004 Harald Hoyer <harald@redhat.com> - 14:3.8.2-6
+- added libpcap-0.8.3-ppp.patch for ppp (bug 128053)
+
+* Wed Jun 23 2004 Elliot Lee <sopwith@redhat.com>
+- added flex to BuildRequires
+
+* Tue Jun 15 2004 Elliot Lee <sopwith@redhat.com>
+- rebuilt
+
+* Sun May 30 2004 Florian La Roche <Florian.LaRoche@redhat.de>
+- simplify rpm scripts
+
+* Tue Apr  6 2004 Harald Hoyer <harald@redhat.com> - 14:3.8.2-3
+- added LICENSE files
+
+* Wed Mar 31 2004 Harald Hoyer <harald@redhat.com> - 14:3.8.2-2
+- update to libpcap-0.8.3 (tcpdump-3.8.3 seems to be older that 3.8.2!!)
+
+* Tue Mar 30 2004 Harald Hoyer <harald@redhat.com> - 14:3.8.2-1
+- update to tcpdump-3.8.2, libpcap-0.8.2, arpwatch-2.1a13
+- patched tcpdump configure for gcc34 optimizations
+- removed obsolete patches
+
+* Tue Mar 02 2004 Elliot Lee <sopwith@redhat.com>
+- rebuilt
+
+* Fri Feb 13 2004 Elliot Lee <sopwith@redhat.com>
+- rebuilt
+
+* Tue Jan 23 2004 Harald Hoyer <harald@redhat.de> 14:3.8.1-4/17
+- fixed arpwatch version
+- fixed libpcap library version
+- fixed tcpdump droproot
+
+* Tue Jan 20 2004 Harald Hoyer <harald@redhat.de> 14:3.8.1-3
+- corrected tcpslice (bpf.h issue)
+
+* Tue Jan 13 2004 Harald Hoyer <harald@redhat.de> 14:3.8.1-2
+- more security issues (patch 18)
+
+* Fri Jan 09 2004 Phil Knirsch <pknirsch@redhat.com> 14:3.8.1-1
+- Updated to latest version because of security issue
+
+* Fri Aug 29 2003 Harald Hoyer <harald@redhat.de> 14:3.7.2-7
+- build libpcap shared library with gcc and not ld
+
+* Tue Jul 22 2003 Phil Knirsch <pknirsch@redhat.com> 14:3.7.2-6.1
+- rebuilt
+
+* Mon Jul 21 2003 Phil Knirsch <pknirsch@redhat.com> 14:3.7.2-6
+- rebuilt
+
+* Wed Jun 04 2003 Elliot Lee <sopwith@redhat.com>
+- rebuilt
+
+* Wed May 21 2003 Harald Hoyer <harald@redhat.de> 14:3.7.2-5
+- add proper attributes for arp.dat, ethercodes
+
+* Tue May 20 2003 Harald Hoyer <harald@redhat.de> 14:3.7.2-4
+- take ethercodes.dat from the arpwatch package now
+
+* Tue May  6 2003 Harald Hoyer <harald@redhat.de> 14:3.7.2-3
+- compile tcpdump with autoheader #90208
+
+* Thu May  1 2003 Elliot Lee <sopwith@redhat.com> 14:3.7.2-2
+- Add sctpdef patch to fix ppc64 builds
+
+* Thu Feb 27 2003 Phil Knirsch <pknirsch@redhat.com> 14:3.7.2-1
+- Update to upstream version 3.7.2
+
+* Sat Feb 01 2003 Florian La Roche <Florian.LaRoche@redhat.de>
+- sanitized rpm scripts
+
+* Wed Jan 22 2003 Tim Powers <timp@redhat.com> 12:3.6.3-20
+- rebuilt
+
+* Tue Jan  7 2003 Nalin Dahyabhai <nalin@redhat.com> 12:3.6.3-19/0.6.2-19/2.1a11-19
+- rebuild
+
+* Sat Jan  4 2003 Jeff Johnson <jbj@redhat.com> 12:3.6.3-18/0.6.2-18/2.1a11-18
+- set execute bits on library so that requires are generated.
+
+* Wed Dec 11 2002 Harald Hoyer <harald@redhat.de> 12:3.6.3-17/0.6.2-17/2.1a11-17
+- common release no. across all subpackages
+
+* Wed Dec 11 2002 Harald Hoyer <harald@redhat.de> 12:3.6.3-5/0.6.2-16/2.1a11-16
+- print_bgp security fix
+
+* Mon Nov 18 2002 Tim Powers <timp@redhat.com>
+- rebuild on all arches
+
+* Fri Aug  2 2002 Harald Hoyer <harald@redhat.de> 12:3.6.3-3/0.6.2-16/2.1a11-16
+- added man page descriptions for the new parameters
+
+* Thu Aug  1 2002 Harald Hoyer <harald@redhat.de> 12:3.6.3-2
+- added arpwatch options to specify sender and recipient (#70386)
+
+* Tue Jul 23 2002 Harald Hoyer <harald@redhat.de> 12:3.6.3-1
+- removed prestripping
+
+* Thu May 16 2002 Harald Hoyer <harald@redhat.de> 12:3.6.2-13
+- added official 3.6.3 fix
+- fixed 6.2 compat #63113
+
+* Wed Jan 23 2002 Harald Hoyer <harald@redhat.de> 12:3.6.2-12
+- tcpdump-3.6.2-snaplen.patch added to fix #55145
+
+* Tue Dec 18 2001 Harald Hoyer <harald@redhat.de> 12:3.6.2-10
+- took old purge patch for filters
+- fixed #54225,#58346
+- drop root by default #49635
+- fixed #54593
+- fixed #57711
+
+* Fri Aug 31 2001 Harald Hoyer <harald@redhat.de> 12:3.6.2-9
+- took better fix for #52654 from tcpdump cvs
+
+* Thu Aug 30 2001 Harald Hoyer <harald@redhat.de> 11:3.6.2-8
+- fixed #52654
+
+* Thu Jul 19 2001 Harald Hoyer <harald@redhat.de> 10:3.6.2-7
+- added shared library to libpcap (#47174)
+- afs printing security patch (#49294)
+
+* Wed Jun 20 2001 Harald Hoyer <harald@redhat.de>
+- use initgroups, instead of setgroups
+
+* Mon Jun 18 2001 Harald Hoyer <harald@redhat.de>
+- added dropgroup patches (#44563)
+
+* Mon May 07 2001 Harald Hoyer <harald@redhat.de>
+- switched to Pekka's tcpdump-3.6.2 package
+- incremented epoch
+
+* Sat Apr 14 2001 Pekka Savola <pekkas@netcore.fi>
+- fix building of tcpslice on glibc 2.2.2 (time.h)
+- disable /etc/init.d requirement and fix %%post scripts in arpwatch
+
+* Wed Feb 14 2001 Harald Hoyer <harald@redhat.de>
+- glibc sys/time -> time include patch
+
+* Wed Feb  7 2001 Trond Eivind Glomsrød <teg@redhat.com>
+- Add space to this check
+
+* Wed Feb 07 2001 Harald Hoyer <harald@redhat.com>
+- added check for presence of /etc/sysconfig/arpwatch (#23172)
+
+* Wed Feb  7 2001 Pekka Savola <pekkas@netcore.fi>
+- update to 3.6.2, 0.6.2 and new CVS of tcpslice.
+- i18n'ize arpwatch init script
+
+* Fri Feb  2 2001 Trond Eivind Glomsrød <teg@redhat.com>
+- i18nize initscript
+
+* Mon Jan 29 2001 Harald Hoyer <harald@redhat.com>
+- fixed EINTR stopping for e.g. SIGSTOP. (#22008)
+- added -u option for tcpdump (#20231)
+- new arpwatch version (#23172)
+- added "all" and "one" interface for -i (#20907)
+- added arpwatch sysconfig (#23172)
+
+* Mon Jan 22 2001 Harald Hoyer <harald@redhat.com>
+- more (potential) overflows in libpcap. #21373
+- documentation fix for #20906
+
+* Sun Jan 14 2001 Pekka Savola <pekkas@netcore.fi>
+- use --enable-ipv6
+- Add two patches from CVS to enhance 802.2 printing, and more importantly,
+  to be able to specify 'no stp'
+
+* Sat Jan 13 2001 Pekka Savola <pekkas@netcore.fi>
+- Make SMB printing output a lot more quiet unless in verbose mode.
+- Make -n resolve port/protocol numbers but not hostnames, -nn for no
+  resolving at all
+- Separate droproot patch from a more generic man/usage fix one
+- Add non-promiscuous mode -by default patch, but don't apply it by default
+
+* Thu Jan 11 2001 Pekka Savola <pekkas@netcore.fi>
+- Update to tcpdump 3.6.1 and libpcap 0.6.1 releases.
+
+* Mon Jan  8 2001 Pekka Savola <pekkas@netcore.fi>
+- Update to 20010108 CVS, disable some upstreamed patches.
+- Change some additional .1 pages to .8.
+- Add droproot patch, some --usage and man page fixes.
+
+* Mon Jan  1 2001 Pekka Savola <pekkas@netcore.fi>
+- Initial packaging with latest tcpdump.org CVS tcpdump-3.6 and libpcap-0.6.
+- add earlier print-domain.c, the latest is segfaulting
+- don't unnecesessarily include snprintf.o, it didn't compile with gcc 2.96 anyway
+- don't use savestr, require openssl, tweak tweak tweak
+- add tcpslice, patch it a bit for egcs detection
+
+* Sun Dec 31 2000 Pekka Savola <pekkas@netcore.fi>
+- tcpdump: spice up the manpage about interfaces
+- tcpdump: add 'all' and 'any' keywords to -i, saner default behaviour.
+- upgrade arpwatch to 2.1a10
+
+* Sun Nov 26 2000 Jeff Johnson <jbj@redhat.com>
+- more (potential) overflows in libpcap.
+
+* Sun Nov 12 2000 Jeff Johnson <jbj@redhat.com>
+- eliminate still more buffer overflows (from FreeBSD) (#20069).
+
+* Thu Nov  2 2000 Jeff Johnson <jbj@redhat.com>
+- eliminate more buffer overflows (from FreeBSD) (#20069).
+- 802.1q ether type incorrect (#19850).
+- add -u flag to drop arpwatch privs (#19696).
+
+* Sun Oct 15 2000 Jeff Johnson <jbj@redhat.com>
+- updated ethercodes.dat
+
+* Thu Oct 12 2000 Jeff Johnson <jbj@redhat.com>
+- fix arpwatch tmp race (#18943).
+
+* Fri Aug 11 2000 Bill Nottingham <notting@redhat.com>
+- fix condrestart
+
+* Fri Aug 11 2000 Jeff Johnson <jbj@redhat.com>
+- correct arpsnmp man pages (#15442).
+- don't print harmless ENOPROTOOPT message (#13518).
+
+* Fri Aug  4 2000 Jeff Johnson <jbj@redhat.com>
+- rebuild with final kernel headers (#13518).
+
+* Sat Jul 22 2000 Jeff Johnson <jbj@redhat.com>
+- add STP patch (#14112).
+
+* Fri Jul 14 2000 Matt Wilson <msw@redhat.com>
+- source /etc/init.d/functions
+- back out /etc/init.d/arpwatch, place file in /etc/rc.d
+- move initscript to /etc/init.d
+- changed initscript to use start() and stop() functions
+- added condrestart to init script
+- added %%post %%preun %%postun scripts to register arpwatch script
+- added Prereq: for all things needed in post/preun/postun
+
+* Wed Jul 12 2000 Prospector <bugzilla@redhat.com>
+- automatic rebuild
+
+* Tue Jul 11 2000 Jeff Johnson <jbj@redhat.com>
+- updated man page and help (pekkas@netcore.fi) (#10739 et al).
+
+* Sun Jun 18 2000 Jeff Johnson <jbj@redhat/com>
+- FHS packaging.
+
+* Tue May  9 2000 Bill Nottingham <notting@redhat.com>
+- minor tweaks for ia64 (prototypes)
+
+* Thu Feb 17 2000 Bernhard Rosenkraenzer <bero@redhat.com>
+- Compile shared libpcap with -fPIC (Bug #6342)
+
+* Wed Feb 02 2000 Cristian Gafton <gafton@redhat.com>
+- fix descriptions
+- man pages are compressed
+
+* Wed Dec 22 1999 Jeff Johnson <jbj@redhat.com>
+- remove sparc64 SIOCGIFNAME hack, not needed with (at least) kernel 2.2.12-40.
+- upgrade to ANK ss991030 snapshot with pcap magic fix (#6773).
+- add getprotobyname lookup (#6725).
+- getservbyname port lookup appears functional (#7569).
+- remove uid 2090 backdoor (sorry Dave) (#7116).
+
+* Thu Sep 09 1999 Cristian Gafton <gafton@redhat.com>
+- fox the pcap.h header
+
+* Fri Aug 20 1999 Jeff Johnson <jbj@redhat.com>
+- prevent segfault on obscure spoofed ip header (#4634).
+
+* Wed Aug 18 1999 Jeff Johnson <jbj@redhat.com>
+- add defattr to arpwatch (#4591).
+
+* Mon Aug 16 1999 Bill Nottingham <notting@redhat.com>
+- initscript munging
+
+* Sun Aug  8 1999 Jeff Johnson <jbj@redhat.com>
+- add -DWORDS_BIGINDIAN to tcpdump compile on sparc sparc61.
+
+* Tue Aug  3 1999 Jeff Johnson <jbj@redhat.com>
+- include A. Kuznetsov's patches to libpcap/tcpdump.
+- added arpsnmp to package (#3258).
+- arp2ethers written for different of awk (#4326).
+
+* Sun Mar 21 1999 Cristian Gafton <gafton@redhat.com>
+- auto rebuild in the new build environment (release 10)
+
+* Fri Mar 19 1999 Jeff Johnson <jbj@redhat.com>
+- strip binaries.
+
+* Wed Jan 13 1999 Bill Nottingham <notting@redhat.com>
+- autoconf fixes for arm
+
+* Tue Sep 29 1998 Jeff Johnson <jbj@redhat.com>
+- libpcap description typo.
+
+* Sat Sep 19 1998 Jeff Johnson <jbj@redhat.com>
+- fix arpwatch summary line.
+
+* Mon Aug 17 1998 Jeff Johnson <jbj@redhat.com>
+- enable arpwatch
+
+* Mon Aug  3 1998 Jeff Johnson <jbj@redhat.com>
+- separate package for libpcap.
+- update tcpdump to 3.4, libpcap to 0.4.
+- added arpwatch (but disabled for now)
+
+* Thu May 07 1998 Prospector System <bugs@redhat.com>
+- translations modified for de, fr, tr
+
+* Sat May  2 1998 Alan Cox <alan@rehat.com>
+- Added the SACK printing fix so you can dump Linux 2.1+.
+
+* Tue Oct 21 1997 Erik Troan <ewt@redhat.com>
+- updated to release 3.4a5
+- uses a buildroot and %%attr
+
+* Thu Jul 17 1997 Erik Troan <ewt@redhat.com>
+- built against glibc


### PR DESCRIPTION
* rebuild for openssl3
* scratch build: https://koji.xcp-ng.org/taskinfo?taskID=89698

Update from @rzr

- [x] Koji build Scratch (v8.3-incoming): https://koji.xcp-ng.org/taskinfo?taskID=94219
- [x] Koji pre-build XCPNG2710 (v8.3-u-pcoval2): https://koji.xcp-ng.org/taskinfo?taskID=94222

